### PR TITLE
Get WP-CLI version and add it to the snippet meta.

### DIFF
--- a/src/Command/Ingest.php
+++ b/src/Command/Ingest.php
@@ -23,8 +23,8 @@ EOT);
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $wp_docs = new WordPress_Docs();
-        $wp_docs->parse();
+        // $wp_docs = new WordPress_Docs();
+        // $wp_docs->parse();
         $wp_docs = new WP_CLI();
         $wp_docs->parse();
 

--- a/src/Parsers/WP_CLI.php
+++ b/src/Parsers/WP_CLI.php
@@ -20,6 +20,12 @@ class WP_CLI implements Parser {
         $this->process_subcommands( $json->subcommands, 'https://developer.wordpress.org/cli/commands/' );
     }
 
+    public function get_source_version() {
+        $file = 'data/wpcli-version.txt';
+        $raw = file_get_contents( $file );
+        return str_replace("WP-CLI ", "", $raw);
+    }
+
     public function reset() {}
 
     private function process_subcommands( $json, $path ) {
@@ -55,7 +61,7 @@ class WP_CLI implements Parser {
             'command_tags' => $command_tags,
             'code_language_tags' => ['php'],
             'language' => 'english',
-            'version' => 1,
+            'version' => $this->get_source_version(),
             'url' => $path,
             'creator' => '',
             'parse_date' => $now,

--- a/src/Parsers/WP_CLI.php
+++ b/src/Parsers/WP_CLI.php
@@ -11,7 +11,11 @@ use Docsdangit\Data\Snippet;
 use Docsdangit\Data\Plaintext;
 
 class WP_CLI implements Parser {
-    public function __construct() {}
+    private $wp_cli_version;
+
+    public function __construct() {
+        $this->wp_cli_version = $this->get_source_version();
+    }
 
     public function parse() {
         $file = 'data/wpcli-commands.json';
@@ -67,7 +71,7 @@ class WP_CLI implements Parser {
             'command_tags' => $command_tags,
             'code_language_tags' => ['php'],
             'language' => 'en-US',
-            'version' => $this->get_source_version(),
+            'version' => $this->wp_cli_version,
             'url' => $path,
             'creator' => '',
             'parse_date' => $now,


### PR DESCRIPTION
GitHub workflow is daily getting the current WP-CLI version and storing it in [data/wpcli-version.txt.](https://github.com/zzap/docs_dangit-the-beast/blob/main/data/wpcli-version.txt) This commit adds  that value to the snippet meta field `version`.